### PR TITLE
Correção de incompatibilidade de ReflectionClass com stdClass

### DIFF
--- a/src/Cielo/API30/Ecommerce/Browser.php
+++ b/src/Cielo/API30/Ecommerce/Browser.php
@@ -32,7 +32,7 @@ class Browser implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try{

--- a/src/Cielo/API30/Ecommerce/Cart.php
+++ b/src/Cielo/API30/Ecommerce/Cart.php
@@ -29,7 +29,7 @@ class Cart implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {

--- a/src/Cielo/API30/Ecommerce/FraudAnalysis.php
+++ b/src/Cielo/API30/Ecommerce/FraudAnalysis.php
@@ -48,7 +48,7 @@ class FraudAnalysis implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {

--- a/src/Cielo/API30/Ecommerce/Item.php
+++ b/src/Cielo/API30/Ecommerce/Item.php
@@ -48,7 +48,7 @@ class Item implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {

--- a/src/Cielo/API30/Ecommerce/Leg.php
+++ b/src/Cielo/API30/Ecommerce/Leg.php
@@ -27,7 +27,7 @@ class Leg implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {

--- a/src/Cielo/API30/Ecommerce/MerchantDefinedField.php
+++ b/src/Cielo/API30/Ecommerce/MerchantDefinedField.php
@@ -27,7 +27,7 @@ class MerchantDefinedField implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {

--- a/src/Cielo/API30/Ecommerce/Passenger.php
+++ b/src/Cielo/API30/Ecommerce/Passenger.php
@@ -35,7 +35,7 @@ class Passenger implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {

--- a/src/Cielo/API30/Ecommerce/ReplyData.php
+++ b/src/Cielo/API30/Ecommerce/ReplyData.php
@@ -45,7 +45,7 @@ class ReplyData implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {

--- a/src/Cielo/API30/Ecommerce/Shipping.php
+++ b/src/Cielo/API30/Ecommerce/Shipping.php
@@ -28,7 +28,7 @@ class Shipping implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {

--- a/src/Cielo/API30/Ecommerce/Travel.php
+++ b/src/Cielo/API30/Ecommerce/Travel.php
@@ -30,7 +30,7 @@ class Travel implements \JsonSerializable
 
     public function populate(\stdClass $data)
     {
-        $reflect = new \ReflectionClass($data);
+        $reflect = new \ReflectionObject($data);
         $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
         foreach ($props as $prop) {
             try {


### PR DESCRIPTION
Identificado nas versões 5.6 e 7.0 do PHP.
Exemplo:
http://phpfiddle.org/main/code/1r0y-9dvt
Alterado de ReflectionClass para ReflectionObject.